### PR TITLE
Updated Selector

### DIFF
--- a/facebook_page_scraper/element_finder.py
+++ b/facebook_page_scraper/element_finder.py
@@ -70,7 +70,7 @@ class Finder():
             elif layout == "new":
                 #links = post.find_elements(By.CSS_SELECTOR,"a[role='link']")
                 link = post.find_element(
-                    By.CSS_SELECTOR, '.jxuftiz4.cxfqmxzd.tes86rjd')
+                    By.CSS_SELECTOR, 'span > a[aria-label][role="link"]')
                 status_link = link.get_attribute('href')
                 status = Scraping_utilities._Scraping_utilities__extract_id_from_link(
                     status_link)

--- a/facebook_page_scraper/scraper.py
+++ b/facebook_page_scraper/scraper.py
@@ -182,7 +182,6 @@ class Facebook_scraper:
             self.__driver, self.__layout)  # find all posts
         all_posts = self.__remove_duplicates(
             all_posts)  # remove duplicates from the list
-
         # iterate over all the posts and find details from the same
         for post in all_posts:
             try:
@@ -291,6 +290,5 @@ class Facebook_scraper:
                     "post_url": post_url
 
                 }
-
             except Exception as ex:
                 print("error at find_elements method : {}".format(ex))


### PR DESCRIPTION
- Fixed Post URL was not found as Facebook's selector was outdated according to the current layout.
- [This ](https://github.com/shaikhsajid1111/facebook_page_scraper/issues/26#issuecomment-1267049115)issue was covered 