### PR TITLE
adding IndexError to __accept_cookie

### DIFF
--- a/facebook_page_scraper/element_finder.py
+++ b/facebook_page_scraper/element_finder.py
@@ -12,16 +12,17 @@ from selenium.webdriver.common.by import By
 import logging
 
 logger = logging.getLogger(__name__)
-format = logging.Formatter(
-    "%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+format = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 ch = logging.StreamHandler()
 ch.setFormatter(format)
 logger.addHandler(ch)
 
-class Finder():
+
+class Finder:
     """
     Holds the collections of methods that finds element of the facebook's posts using selenium's webdriver's methods
     """
+
     @staticmethod
     def __get_status_link(link_list):
         status = ""
@@ -62,18 +63,22 @@ class Finder():
             if layout == "old":
                 # aim is to find element that looks like <a href="URL" class="_5pcq"></a>
                 # after finding that element, get it's href value and pass it to different method that extracts post_id from that href
-                status_link = post.find_element(
-                    By.CLASS_NAME, "_5pcq").get_attribute("href")
+                status_link = post.find_element(By.CLASS_NAME, "_5pcq").get_attribute(
+                    "href"
+                )
                 # extract out post id from post's url
                 status = Scraping_utilities._Scraping_utilities__extract_id_from_link(
-                    status_link)
+                    status_link
+                )
             elif layout == "new":
-                #links = post.find_elements(By.CSS_SELECTOR,"a[role='link']")
+                # links = post.find_elements(By.CSS_SELECTOR,"a[role='link']")
                 link = post.find_element(
-                    By.CSS_SELECTOR, 'span > a[aria-label][role="link"]')
-                status_link = link.get_attribute('href')
+                    By.CSS_SELECTOR, 'span > a[aria-label][role="link"]'
+                )
+                status_link = link.get_attribute("href")
                 status = Scraping_utilities._Scraping_utilities__extract_id_from_link(
-                    status_link)
+                    status_link
+                )
         except NoSuchElementException:
             # if element is not found
             status = "NA"
@@ -91,12 +96,13 @@ class Finder():
             if layout == "old":
                 # aim is to find element that have datatest-id attribute as UFI2SharesCount/root
                 shares = post.find_element(
-                    By.CSS_SELECTOR, "._355t._4vn2").get_attribute('textContent')
-                shares = Scraping_utilities._Scraping_utilities__extract_numbers(
-                    shares)
+                    By.CSS_SELECTOR, "._355t._4vn2"
+                ).get_attribute("textContent")
+                shares = Scraping_utilities._Scraping_utilities__extract_numbers(shares)
             elif layout == "new":
                 elements = post.find_elements(
-                    By.CSS_SELECTOR, 'div[role="button"] > span')
+                    By.CSS_SELECTOR, 'div[role="button"] > span'
+                )
                 shares = "0"
                 for element in elements:
                     text = element.text
@@ -120,7 +126,8 @@ class Finder():
         try:
             # find element that have attribute aria-label as 'See who reacted to this
             reactions_all = post.find_element(
-                By.CSS_SELECTOR, '[aria-label="See who reacted to this"]')
+                By.CSS_SELECTOR, '[aria-label="See who reacted to this"]'
+            )
         except NoSuchElementException:
             reactions_all = ""
         except Exception as ex:
@@ -133,20 +140,26 @@ class Finder():
         try:
             comments = ""
             if layout == "old":
-                comments = post.find_element(
-                    By.CSS_SELECTOR, "a._3hg-").get_attribute('textContent')
+                comments = post.find_element(By.CSS_SELECTOR, "a._3hg-").get_attribute(
+                    "textContent"
+                )
                 # extract numbers from text
                 comments = Scraping_utilities._Scraping_utilities__extract_numbers(
-                    comments)
+                    comments
+                )
             elif layout == "new":
                 elements = post.find_elements(
-                    By.CSS_SELECTOR, 'div[role="button"] > span')
+                    By.CSS_SELECTOR, 'div[role="button"] > span'
+                )
                 comments = 0
                 for element in elements:
                     text = element.text
                     if "comment" in text:
-                        comments = Scraping_utilities._Scraping_utilities__extract_numbers(
-                            text)
+                        comments = (
+                            Scraping_utilities._Scraping_utilities__extract_numbers(
+                                text
+                            )
+                        )
                         break
         except NoSuchElementException:
             comments = 0
@@ -161,14 +174,16 @@ class Finder():
 
         response = urllib.request.urlopen(href)
 
-        text = response.read().decode('utf-8')
+        text = response.read().decode("utf-8")
 
-        post_message_div_finder_regex = '<div data-testid="post_message" class=".*?" data-ft=".*?">(.*?)<\/div>'
+        post_message_div_finder_regex = (
+            '<div data-testid="post_message" class=".*?" data-ft=".*?">(.*?)<\/div>'
+        )
 
         post_message = re.search(post_message_div_finder_regex, text)
 
-        replace_html_tags_regex = '<[^<>]+>'
-        message = re.sub(replace_html_tags_regex, '', post_message.group(0))
+        replace_html_tags_regex = "<[^<>]+>"
+        message = re.sub(replace_html_tags_regex, "", post_message.group(0))
 
         return message
 
@@ -185,25 +200,31 @@ class Finder():
         """finds content of the facebook post using selenium's webdriver's method and returns string containing text of the posts"""
         try:
             if layout == "old":
-                post_content = post.find_element(By.CLASS_NAME, 'userContent')
+                post_content = post.find_element(By.CLASS_NAME, "userContent")
                 # if 'See more' or 'Continue reading' is present in post
-                if Finder._Finder__element_exists(post_content, "span.text_exposed_link > a"):
+                if Finder._Finder__element_exists(
+                    post_content, "span.text_exposed_link > a"
+                ):
                     element = post_content.find_element(
-                        By.CSS_SELECTOR, "span.text_exposed_link > a")  # grab that element
+                        By.CSS_SELECTOR, "span.text_exposed_link > a"
+                    )  # grab that element
                     # if element have already the onclick function, that means it is expandable paragraph
                     if element.get_attribute("onclick"):
                         # click 'see more' button to get hidden text as well
-                        Utilities._Utilities__click_see_more(
-                            driver, post_content)
-                        content = Scraping_utilities._Scraping_utilities__extract_content(
-                            post_content)  # extract content out of it
+                        Utilities._Utilities__click_see_more(driver, post_content)
+                        content = (
+                            Scraping_utilities._Scraping_utilities__extract_content(
+                                post_content
+                            )
+                        )  # extract content out of it
                     # if element have attribute of target="_blank"
                     elif element.get_attribute("target"):
                         # if it does not have onclick() method, it means we'll to extract passage by request
                         # if content have attribute target="_blank" it indicates that text will open in new tab,
                         # so make a seperate request and get that text
                         content = Finder._Finder__fetch_post_passage(
-                            element.get_attribute("href"))
+                            element.get_attribute("href")
+                        )
                     else:
                         content = post_content.get_attribute("textContent")
                 else:
@@ -211,19 +232,26 @@ class Finder():
                     content = post_content.get_attribute("textContent")
             elif layout == "new":
                 post_content = post.find_element(
-                    By.CSS_SELECTOR, '[data-ad-preview="message"]')
+                    By.CSS_SELECTOR, '[data-ad-preview="message"]'
+                )
                 # if "See More" button exists
-                if Finder._Finder__element_exists(post_content, 'div[dir="auto"] > div[role]'):
+                if Finder._Finder__element_exists(
+                    post_content, 'div[dir="auto"] > div[role]'
+                ):
                     element = post_content.find_element(
-                        By.CSS_SELECTOR, 'div[dir="auto"] > div[role]')  # grab that element
+                        By.CSS_SELECTOR, 'div[dir="auto"] > div[role]'
+                    )  # grab that element
                     if element.get_attribute("target"):
                         content = Finder._Finder__fetch_post_passage(
-                            element.get_attribute("href"))
+                            element.get_attribute("href")
+                        )
                     else:
                         Utilities._Utilities__click_see_more(
-                            driver, post_content, 'div[dir="auto"] > div[role]')
+                            driver, post_content, 'div[dir="auto"] > div[role]'
+                        )
                         content = post_content.get_attribute(
-                            "textContent")  # extract content out of it
+                            "textContent"
+                        )  # extract content out of it
                 else:
                     # if it does not have see more, just get the text out of it
                     content = post_content.get_attribute("textContent")
@@ -241,25 +269,31 @@ class Finder():
         """finds posted time of the facebook post using selenium's webdriver's method"""
         try:
             # extract element that looks like <abbr class='_5ptz' data-utime="some unix timestamp"> </abbr>
-            #posted_time = post.find_element_by_css_selector("abbr._5ptz").get_attribute("data-utime")
+            # posted_time = post.find_element_by_css_selector("abbr._5ptz").get_attribute("data-utime")
             if layout == "old":
-                posted_time = post.find_element(
-                    By.TAG_NAME, "abbr").get_attribute('data-utime')
+                posted_time = post.find_element(By.TAG_NAME, "abbr").get_attribute(
+                    "data-utime"
+                )
                 return datetime.datetime.fromtimestamp(float(posted_time)).isoformat()
             elif layout == "new":
                 aria_label_value = link_element.get_attribute("aria-label")
-                timestamp = parse(aria_label_value).isoformat() if len(
-                    aria_label_value) > 5 else Scraping_utilities._Scraping_utilities__convert_to_iso(aria_label_value)
+                timestamp = (
+                    parse(aria_label_value).isoformat()
+                    if len(aria_label_value) > 5
+                    else Scraping_utilities._Scraping_utilities__convert_to_iso(
+                        aria_label_value
+                    )
+                )
                 return timestamp
         except dateutil.parser._parser.ParserError:
             timestamp = Scraping_utilities._Scraping_utilities__convert_to_iso(
-                aria_label_value)
+                aria_label_value
+            )
             return timestamp
         except TypeError:
             timestamp = ""
         except Exception as ex:
-            logger.exception(
-                "Error at find_posted_time method : {}".format(ex))
+            logger.exception("Error at find_posted_time method : {}".format(ex))
             timestamp = ""
             return timestamp
 
@@ -271,7 +305,7 @@ class Finder():
             video_element = post.find_elements(By.TAG_NAME, "video")
             srcs = []
             for video in video_element:
-              srcs.append(video.get_attribute("src"))
+                srcs.append(video.get_attribute("src"))
         except NoSuchElementException:
             video = []
             pass
@@ -288,13 +322,18 @@ class Finder():
             if layout == "old":
                 # find all img tag that looks like <img class="scaledImageFitWidth img" src=""> div > img[referrerpolicy]
                 images = post.find_elements(
-                    By.CSS_SELECTOR, "img.scaledImageFitWidth.img")
+                    By.CSS_SELECTOR, "img.scaledImageFitWidth.img"
+                )
                 # extract src attribute from all the img tag,store it in list
             elif layout == "new":
                 images = post.find_elements(
-                    By.CSS_SELECTOR, "div > img[referrerpolicy]")
-            sources = [image.get_attribute("src") for image in images] if len(
-                images) > 0 else []
+                    By.CSS_SELECTOR, "div > img[referrerpolicy]"
+                )
+            sources = (
+                [image.get_attribute("src") for image in images]
+                if len(images) > 0
+                else []
+            )
         except NoSuchElementException:
             sources = []
             pass
@@ -311,10 +350,10 @@ class Finder():
             # find all posts that looks like <div class="userContentWrapper"> </div>
             if layout == "old":
                 all_posts = driver.find_elements(
-                    By.CSS_SELECTOR, "div.userContentWrapper")
+                    By.CSS_SELECTOR, "div.userContentWrapper"
+                )
             elif layout == "new":
-                all_posts = driver.find_elements(
-                    By.CSS_SELECTOR, 'div[role="article"]')
+                all_posts = driver.find_elements(By.CSS_SELECTOR, 'div[role="article"]')
             return all_posts
         except NoSuchElementException:
             logger.error("Cannot find any posts! Exiting!")
@@ -322,8 +361,7 @@ class Finder():
             Utilities.__close_driver(driver)
             sys.exit(1)
         except Exception as ex:
-            logger.exception(
-                "Error at find_all_posts method : {}".format(ex))
+            logger.exception("Error at find_all_posts method : {}".format(ex))
             Utilities.__close_driver(driver)
             sys.exit(1)
 
@@ -332,11 +370,13 @@ class Finder():
         """finds name of the facebook page using selenium's webdriver's method"""
         try:
             if layout == "old":
-                name = driver.find_element(
-                    By.CSS_SELECTOR, 'a._64-f').get_attribute('textContent')
+                name = driver.find_element(By.CSS_SELECTOR, "a._64-f").get_attribute(
+                    "textContent"
+                )
             elif layout == "new":
-                name = driver.find_element(
-                    By.TAG_NAME, "strong").get_attribute("textContent")
+                name = driver.find_element(By.TAG_NAME, "strong").get_attribute(
+                    "textContent"
+                )
             return name
         except Exception as ex:
             logger.exception("Error at __find_name method : {}".format(ex))
@@ -357,11 +397,9 @@ class Finder():
     def __find_reaction(layout, reactions_all):
         try:
             if layout == "old":
-                return reactions_all.find_elements(By.TAG_NAME,
-                                                   "a")
+                return reactions_all.find_elements(By.TAG_NAME, "a")
             elif layout == "new":
-                return reactions_all.find_elements(By.TAG_NAME,
-                                                   "div")
+                return reactions_all.find_elements(By.TAG_NAME, "div")
 
         except Exception as ex:
             logger.exception("Error at find_reaction : {}".format(ex))
@@ -369,11 +407,13 @@ class Finder():
 
     @staticmethod
     def __accept_cookies(driver):
-      try:
-        button = driver.find_elements(By.CSS_SELECTOR, '[aria-label="Allow essential and optional cookies"]')
-        button[-1].click()
-      except NoSuchElementException:
-        pass
-      except Exception as ex:
-        logger.exception('Error at accept_cookies: {}'.format(ex))
-        sys.exit(1)
+        try:
+            button = driver.find_elements(
+                By.CSS_SELECTOR, '[aria-label="Allow essential and optional cookies"]'
+            )
+            button[-1].click()
+        except (NoSuchElementException, IndexError):
+            pass
+        except Exception as ex:
+            logger.exception("Error at accept_cookies: {}".format(ex))
+            sys.exit(1)


### PR DESCRIPTION
The __accept_cookies method is throwing errors because of an IndexError in the `button[-1].click()` action. This simple change allows the scrape to continue, just like what is allowed in the case of NoSuchElementException.