### PR TITLE
Adding functionality for scraping FB groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 - Internet Connection
 - Python 3.7+
 - Chrome or Firefox browser installed on your machine
-<br>
+  <br>
 
 <hr>
 <h2 id="Installation">Installation:</h2>
@@ -64,17 +64,17 @@ git clone https://github.com/shaikhsajid1111/facebook_page_scraper
 ```
 python3 setup.py install
 ```
+
 <br>
 <p id="pypiInstallation">Installing with pypi</p>
 
 ```
 pip3 install facebook-page-scraper
 ```
+
 <br>
 <hr>
 <h2 id="instantiation"> How to use? </h2>
-
-
 
 ```python
 #import Facebook_scraper class from facebook_page_scraper
@@ -82,13 +82,18 @@ from facebook_page_scraper import Facebook_scraper
 
 #instantiate the Facebook_scraper class
 
-page_name = "metaai"
+page_or_group_name = "Meta"
 posts_count = 10
 browser = "firefox"
 proxy = "IP:PORT" #if proxy requires authentication then user:password@IP:PORT
 timeout = 600 #600 seconds
 headless = True
-meta_ai = Facebook_scraper(page_name, posts_count, browser, proxy=proxy, timeout=timeout, headless=headless)
+# get env password
+fb_password = os.getenv('fb_password')
+fb_email = os.getenv('fb_email')
+# indicates if the Facebook target is a FB group or FB page
+isGroup= False
+meta_ai = Facebook_scraper(page_or_group_name, posts_count, browser, proxy=proxy, timeout=timeout, headless=headless, isGroup=isGroup)
 
 ```
 
@@ -104,13 +109,13 @@ meta_ai = Facebook_scraper(page_name, posts_count, browser, proxy=proxy, timeout
 
 <tr>
 <td>
-page_name
+page_or_group_name
 </td>
 <td>
 String
 </td>
 <td>
-Name of the facebook page
+Name of the facebook page or group
 </td>
 </tr>
 
@@ -173,7 +178,45 @@ Whether to run browser in headless mode?. Default is True
  </code>
 </td>
 </tr>
+<tr>
 
+<td>
+isGroup
+</td>
+<td>
+Boolean
+</td>
+<td>
+Whether the Facebook target is a group or page. Default is False
+ </code>
+</td>
+</tr>
+
+<tr>
+<td>
+username
+</td>
+<td>
+String
+</td>
+<td>
+username to log into Facebook when scraping (recommended to use .env)
+ </code>
+</td>
+</tr>
+
+<tr>
+<td>
+password
+</td>
+<td>
+String
+</td>
+<td>
+password to log into Facebook when scraping (recommended to use .env)
+ </code>
+</td>
+</tr>
 
 </table>
 <br>
@@ -184,6 +227,7 @@ Whether to run browser in headless mode?. Default is True
 <br
 
 >
+
 <h3 id="JSONWay"> For post's data in <b>JSON</b> format:</h3>
 
 ```python
@@ -224,11 +268,11 @@ Output:
 
 }
 ```
+
 <div id="jsonOutput">
 Output Structure for JSON format:
 
-
-``` javascript
+```javascript
 {
     "id": {
         "name": string,
@@ -253,6 +297,7 @@ Output Structure for JSON format:
 }
 
 ```
+
 </div>
 <br>
 <hr>
@@ -260,7 +305,7 @@ Output Structure for JSON format:
 
 <h3 id="CSVWay"> For saving post's data directly to <b>CSV</b> file</h3>
 
-``` python
+```python
 #call scrap_to_csv(filename,directory) method
 
 
@@ -270,7 +315,8 @@ meta_ai.scrap_to_csv(filename, directory)
 
 ```
 
-content of ```data_file.csv```:
+content of `data_file.csv`:
+
 ```csv
 id,name,shares,likes,loves,wow,cares,sad,angry,haha,reactions_count,comments,content,posted_on,video,image,post_url
 2024182624425347,Meta AI,0,154,19,0,0,0,0,0,173,2,"We’ve built data2vec, the first general high-performance self-supervised algorithm for speech, vision, and text. We applied it to different modalities and found it matches or outperforms the best self-supervised algorithms. We hope this brings us closer to a world where computers can learn to solve many different tasks without supervision. Learn more and get the code:  https://ai.facebook.com/…/the-first-high-performance-self-s…",2022-01-20T22:43:35,,https://scontent-bom1-2.xx.fbcdn.net/v/t39.30808-6/s480x480/272147088_2024182621092014_6532581039236849529_n.jpg?_nc_cat=100&ccb=1-5&_nc_sid=8024bb&_nc_ohc=j4_1PAndJTIAX82OLNq&_nc_ht=scontent-bom1-2.xx&oh=00_AT9us__TvC9eYBqRyQEwEtYSit9r2UKYg0gFoRK7Efrhyw&oe=61F17B71,https://www.facebook.com/MetaAI/photos/a.360372474139712/2024182624425347/?type=3&__xts__%5B0%5D=68.ARAse4eiZmZQDOZumNZEDR0tQkE5B6g50K6S66JJPccb-KaWJWg6Yz4v19BQFSZRMd04MeBmV24VqvqMB3oyjAwMDJUtpmgkMiITtSP8HOgy8QEx_vFlq1j-UEImZkzeEgSAJYINndnR5aSQn0GUwL54L3x2BsxEqL1lElL7SnHfTVvIFUDyNfAqUWIsXrkI8X5KjoDchUj7aHRga1HB5EE0x60dZcHogUMb1sJDRmKCcx8xisRgk5XzdZKCQDDdEkUqN-Ch9_NYTMtxlchz1KfR0w9wRt8y9l7E7BNhfLrmm4qyxo-ZpA&__tn__=-R
@@ -327,8 +373,6 @@ Directory where CSV file have to be stored.
 <hr>
 <br>
 
-
-
 <h3 id="outputKeys">Keys of the outputs:</h3>
 <table>
 <th>
@@ -337,8 +381,6 @@ Directory where CSV file have to be stored.
 <td>
 Key
 </td>
-
-
 
 <td>
 Type
@@ -350,7 +392,6 @@ Description
 
 <tr>
 </th>
-
 
 <td>
 <tr>
@@ -416,7 +457,6 @@ Total reaction count of post
 </td>
 </tr>
 
-
 <tr>
 <td>
 comments
@@ -453,10 +493,9 @@ URLs of video present in that post
 </td>
 </tr>
 
-
 <tr>
 <td>
-image
+images
 </td>
 <td>
  List
@@ -489,7 +528,6 @@ String
 URL for that post
 </td>
 </tr>
-
 
 </table>
 <br>

--- a/facebook_page_scraper/driver_utilities.py
+++ b/facebook_page_scraper/driver_utilities.py
@@ -130,22 +130,28 @@ class Utilities:
                 body = driver.find_element(By.CSS_SELECTOR, "body")
                 for _ in range(randint(3, 5)):
                     body.send_keys(Keys.PAGE_DOWN)
-                WebDriverWait(driver, 30).until(EC.presence_of_element_located(
+                WebDriverWait(driver, timeout).until(EC.presence_of_element_located(
                     (By.CSS_SELECTOR, '.userContentWrapper')))
+                return True
             elif layout == "new":
-                WebDriverWait(driver, 60).until(
+                WebDriverWait(driver, timeout).until(
                     EC.presence_of_element_located((By.CSS_SELECTOR, "[aria-posinset]")))
+                print("new layout loaded")
+
+                return True
 
         except WebDriverException:
             # if it was not found,it means either page is not loading or it does not exists
             logger.critical("No posts were found!")
-            Utilities.__close_driver(driver)
+            return False
+            # Utilities.__close_driver(driver)
             # exit the program, because if posts does not exists,we cannot go further
-            sys.exit(1)
+            # sys.exit(1)
         except Exception as ex:
             logger.exception(
                 "Error at wait_for_element_to_appear method : {}".format(ex))
-            Utilities.__close_driver(driver)
+            return False
+            # Utilities.__close_driver(driver)
 
     @staticmethod
     def __click_see_more(driver, content, selector=None):

--- a/facebook_page_scraper/driver_utilities.py
+++ b/facebook_page_scraper/driver_utilities.py
@@ -144,8 +144,8 @@ class Utilities:
             # if it was not found,it means either page is not loading or it does not exists
             logger.critical("No posts were found!")
             return False
+            # (optional) exit the program, because if posts does not exists,we cannot go further
             # Utilities.__close_driver(driver)
-            # exit the program, because if posts does not exists,we cannot go further
             # sys.exit(1)
         except Exception as ex:
             logger.exception(

--- a/facebook_page_scraper/driver_utilities.py
+++ b/facebook_page_scraper/driver_utilities.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.common.by import By
-from selenium.common.exceptions import NoSuchElementException, WebDriverException
-from random import randint
-from selenium.webdriver.common.keys import Keys
 import logging
 import sys
 import time
+from random import randint
+
+from selenium.common.exceptions import (NoSuchElementException,
+                                        WebDriverException)
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 
 logger = logging.getLogger(__name__)
 format = logging.Formatter(
@@ -118,7 +120,7 @@ class Utilities:
             logger.exception("Error at close_popup method : {}".format(ex))
 
     @staticmethod
-    def __wait_for_element_to_appear(driver, layout):
+    def __wait_for_element_to_appear(driver, layout, timeout):
         """expects driver's instance, wait for posts to show.
         post's CSS class name is userContentWrapper
         """
@@ -131,7 +133,7 @@ class Utilities:
                 WebDriverWait(driver, 30).until(EC.presence_of_element_located(
                     (By.CSS_SELECTOR, '.userContentWrapper')))
             elif layout == "new":
-                WebDriverWait(driver, 30).until(
+                WebDriverWait(driver, 60).until(
                     EC.presence_of_element_located((By.CSS_SELECTOR, "[aria-posinset]")))
 
         except WebDriverException:

--- a/facebook_page_scraper/element_finder.py
+++ b/facebook_page_scraper/element_finder.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import re
 import sys
+import time
 import urllib.request
 
 import dateutil
@@ -475,15 +476,17 @@ class Finder:
     @staticmethod
     def __login(driver, username, password):
         try:
-            # TODO this closes the login modal pop-up if you choose to not login above
+
             wait = WebDriverWait(driver, 4)  # considering that the elements might load a bit slow
+
+            # NOTE this closes the login modal pop-up if you choose to not login above
             try:
                 element = wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, '[aria-label="Close"]')))
                 element.click()  # Click the element
             except Exception as ex:
                 print(f"no pop-up")
-
-            # time.sleep(3)
+            
+            time.sleep(1)
             #target username
             username_element = WebDriverWait(driver, 10).until(EC.element_to_be_clickable((By.CSS_SELECTOR, "input[name='email']")))
             password_element = WebDriverWait(driver, 10).until(EC.element_to_be_clickable((By.CSS_SELECTOR, "input[name='pass']")))

--- a/facebook_page_scraper/element_finder.py
+++ b/facebook_page_scraper/element_finder.py
@@ -7,8 +7,10 @@ import urllib.request
 
 import dateutil
 from dateutil.parser import parse
-from selenium.common.exceptions import NoSuchElementException
+from selenium.common.exceptions import NoSuchElementException, TimeoutException
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 
 from .driver_utilities import Utilities
 from .scraping_utilities import Scraping_utilities
@@ -62,25 +64,86 @@ class Finder:
         try:
             link = None
             status_link = None
+            status = None
+
             if layout == "old":
                 # aim is to find element that looks like <a href="URL" class="_5pcq"></a>
                 # after finding that element, get it's href value and pass it to different method that extracts post_id from that href
                 status_link = post.find_element(By.CLASS_NAME, "_5pcq").get_attribute(
                     "href"
                 )
+                print("old link layouut\n")
                 # extract out post id from post's url
                 status = Scraping_utilities._Scraping_utilities__extract_id_from_link(
                     status_link
                 )
             elif layout == "new":
                 # links = post.find_elements(By.CSS_SELECTOR,"a[role='link']")
+                #THIS METHOD of getting the link seems to return the same as my method of getting the first a tag in the post, which may change. I'll keep both for now
                 link = post.find_element(
-                    By.CSS_SELECTOR, 'span > a[aria-label][role="link"]'
+                    By.CSS_SELECTOR, 'span > a[role="link"]'
                 )
-                status_link = link.get_attribute("href")
-                status = Scraping_utilities._Scraping_utilities__extract_id_from_link(
-                    status_link
-                )
+                if link is not None:
+                    # Assuming 'link' is your WebElement
+                    outer_html = link.get_attribute("outerHTML")
+
+                    # Extracting just the opening tag
+                    opening_tag = outer_html.split('>', 1)[0] + '>'
+
+                    # print("OPENING TAG:\n" + opening_tag[:500])
+
+                    status_link = link.get_attribute("href")
+                    status = Scraping_utilities._Scraping_utilities__extract_id_from_link(
+                        status_link
+                    )
+                    # print("linkkk: " + str(link))
+                    # print("statusss: " + str(status_link))
+                else:
+                    print("no sneaky link")
+
+                links = post.find_elements(By.TAG_NAME, 'a')
+                # Assuming 'link' is your WebElement
+                # outer_html = links.get_attribute("outerHTML")
+
+                # # Extracting just the opening tag
+                # opening_tag = outer_html.split('>', 1)[0] + '>'
+
+                # print("ALL LINKS TAG:\n" + opening_tag[:150])
+                if links:
+                    # Initialize variables to store the matching link element and URL
+                    matching_link_element = None
+                    post_url = None
+
+                    # Iterate over links to find the first one that matches the criteria
+                    for link in links:
+                        href = link.get_attribute('href')
+                        if href and '/groups/' in href:
+                            post_url = href  # Store the URL
+                            matching_link_element = link  # Store the link element
+                            break  # Exit the loop after finding the first match
+
+                    # Check if a matching link was found
+                    if post_url and matching_link_element:
+                        # status_link = post_url
+                        # print("\nURL:", post_url)
+                        # Assuming 'link' is your WebElement
+                        outer_html2 = matching_link_element.get_attribute("outerHTML")
+
+                        # # Extracting just the opening tag
+                        opening_tag = outer_html.split('>', 1)[0] + '>'
+                        # areEqual = outer_html == outer_html2
+                        # print("ARE EQUAL: " + str(areEqual))
+                        # print("OPENING match:\n" + opening_tag[:1000])
+                        status = Scraping_utilities._Scraping_utilities__extract_id_from_link(post_url)
+                        # Now you have the URL, the status, and the matching link element itself
+                        # print("\nURL:", post_url)
+                        return (status, post_url, matching_link_element)
+
+                #     else:
+                #         print("no post url or link element")
+                # else:
+                #     print("no links")
+
         except NoSuchElementException:
             # if element is not found
             status = "NA"
@@ -88,8 +151,9 @@ class Finder:
         except Exception as ex:
             logger.exception("Error at find_status method : {}".format(ex))
             status = "NA"
-
         return (status, status_link, link)
+
+
 
     @staticmethod
     def __find_share(post, layout):
@@ -259,8 +323,9 @@ class Finder:
         return content
 
     @staticmethod
-    def __find_posted_time(post, layout, link_element):
+    def __find_posted_time(post, layout, link_element, driver):
         """finds posted time of the facebook post using selenium's webdriver's method"""
+        # print("POST ELEMENT:\n " + post.get_attribute("outerHTML"))
         try:
             # extract element that looks like <abbr class='_5ptz' data-utime="some unix timestamp"> </abbr>
             # posted_time = post.find_element_by_css_selector("abbr._5ptz").get_attribute("data-utime")
@@ -270,20 +335,51 @@ class Finder:
                 )
                 return datetime.datetime.fromtimestamp(float(posted_time)).isoformat()
             elif layout == "new":
-                aria_label_value = link_element.get_attribute("aria-label")
-                timestamp = (
-                    parse(aria_label_value).isoformat()
-                    if len(aria_label_value) > 5
-                    else Scraping_utilities._Scraping_utilities__convert_to_iso(
-                        aria_label_value
-                    )
-                )
+                # There is no aria_label on these link elements anymore
+                # aria_label_value = link_element.get_attribute("aria-label")
+                # timestamp = (
+                #     parse(aria_label_value).isoformat()
+                #     if len(aria_label_value) > 5
+                #     else Scraping_utilities._Scraping_utilities__convert_to_iso(
+                #         aria_label_value
+                #     )
+                # )
+
+
+                js_script = """
+                    // Starting from the provided element, find the SVG using querySelector
+                    var svgElement = arguments[0].querySelector('svg');
+                    
+                    // Assuming we're looking for a shadow DOM inside or related to the <use> tag, which is unconventional
+                    // var useElement = svgElement.querySelector('use');
+                    
+                    // Placeholder for accessing the shadow DOM, which is not directly applicable to <use> tags.
+                    // This step assumes there's some unconventional method to access related shadow content
+                    var shadowContent;
+                    
+                    // Hypothetically accessing shadow DOM or related content. This part needs adjustment based on actual structure or intent
+                    // As <use> tags don't host shadow DOMs, this is speculative and might represent a different approach in practice
+                    if (svgElement.shadowRoot) {
+                        shadowContent = svgElement.shadowRoot.querySelector('some-element').textContent;
+                    } else {
+                        // Fallback or alternative method to access intended content, as direct shadow DOM access on <use> is not standard
+                        shadowContent = 'Fallback or alternative content access method needed';
+                    }
+                    
+                    return shadowContent;
+                """
+                # Execute the script with the link_element as the argument
+                timestamp = driver.execute_script(js_script, link_element)
+                print("TIMESTAMP: " + str(timestamp))
+
                 return timestamp
-        except dateutil.parser._parser.ParserError:
-            timestamp = Scraping_utilities._Scraping_utilities__convert_to_iso(
-                aria_label_value
-            )
-            return timestamp
+
+
+        # except dateutil.parser._parser.ParserError:
+        #     timestamp = Scraping_utilities._Scraping_utilities__convert_to_iso(
+        #         aria_label_value
+        #     )
+        #     return timestamp
         except TypeError:
             timestamp = ""
         except Exception as ex:
@@ -347,7 +443,9 @@ class Finder:
                     By.CSS_SELECTOR, "div.userContentWrapper"
                 )
             elif layout == "new":
-                all_posts = driver.find_elements(By.CSS_SELECTOR, 'div[role="article"]')
+                all_posts = driver.find_elements(By.CSS_SELECTOR, "div[role='feed'] > div")
+                # all_posts = driver.find_elements(By.CSS_SELECTOR, 'div[role="article"]')
+                # print("found all posts: " + str(all_posts))
             return all_posts
         except NoSuchElementException:
             logger.error("Cannot find any posts! Exiting!")
@@ -362,6 +460,9 @@ class Finder:
     @staticmethod
     def __find_name(driverOrPost, layout):
         """finds name of the facebook page or post using selenium's webdriver's method"""
+        # Attempt to print the outer HTML of the driverOrPost for debugging
+        # print("NAME ELEMENT: " + driverOrPost.get_attribute("outerHTML"))
+        
         try:
             if layout == "old":
                 name = driverOrPost.find_element(By.CSS_SELECTOR, "a._64-f").get_attribute(
@@ -412,3 +513,38 @@ class Finder:
         except Exception as ex:
             logger.exception("Error at accept_cookies: {}".format(ex))
             sys.exit(1)
+
+    @staticmethod
+    def __login(driver, username, password):
+        try:
+            # TODO this closes the login modal pop-up if you choose to not login above
+            wait = WebDriverWait(driver, 4)  # considering that the elements might load a bit slow
+            try:
+                element = wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, '[aria-label="Close"]')))
+                element.click()  # Click the element
+            except Exception as ex:
+                print(f"no pop-up")
+
+            # time.sleep(3)
+            #target username
+            username_element = WebDriverWait(driver, 10).until(EC.element_to_be_clickable((By.CSS_SELECTOR, "input[name='email']")))
+            password_element = WebDriverWait(driver, 10).until(EC.element_to_be_clickable((By.CSS_SELECTOR, "input[name='pass']")))
+
+            #enter username and password
+            username_element.clear()
+            username_element.send_keys(str(username))
+            password_element.clear()
+            password_element.send_keys(str(password))
+
+            #target the login button and click it
+            try:
+                # Try to click the first button of type 'submit'
+                WebDriverWait(driver, 2).until(EC.element_to_be_clickable((By.CSS_SELECTOR, "button[type='submit']"))).click()
+            except TimeoutException:
+                # If the button of type 'submit' is not found within 2 seconds, click the first 'button' found
+                WebDriverWait(driver, 2).until(EC.element_to_be_clickable((By.CSS_SELECTOR, "button"))).click()
+        except (NoSuchElementException, IndexError):
+            pass
+        except Exception as ex:
+            logger.exception("Error at login: {}".format(ex))
+            # sys.exit(1)

--- a/facebook_page_scraper/element_finder.py
+++ b/facebook_page_scraper/element_finder.py
@@ -84,31 +84,12 @@ class Finder:
                     By.CSS_SELECTOR, 'span > a[role="link"]'
                 )
                 if link is not None:
-                    # Assuming 'link' is your WebElement
-                    outer_html = link.get_attribute("outerHTML")
-
-                    # Extracting just the opening tag
-                    opening_tag = outer_html.split('>', 1)[0] + '>'
-
-                    # print("OPENING TAG:\n" + opening_tag[:500])
-
                     status_link = link.get_attribute("href")
                     status = Scraping_utilities._Scraping_utilities__extract_id_from_link(
                         status_link
                     )
-                    # print("linkkk: " + str(link))
-                    # print("statusss: " + str(status_link))
-                else:
-                    print("no sneaky link")
 
                 links = post.find_elements(By.TAG_NAME, 'a')
-                # Assuming 'link' is your WebElement
-                # outer_html = links.get_attribute("outerHTML")
-
-                # # Extracting just the opening tag
-                # opening_tag = outer_html.split('>', 1)[0] + '>'
-
-                # print("ALL LINKS TAG:\n" + opening_tag[:150])
                 if links:
                     # Initialize variables to store the matching link element and URL
                     matching_link_element = None
@@ -124,25 +105,9 @@ class Finder:
 
                     # Check if a matching link was found
                     if post_url and matching_link_element:
-                        # status_link = post_url
-                        # print("\nURL:", post_url)
-                        # Assuming 'link' is your WebElement
-                        outer_html2 = matching_link_element.get_attribute("outerHTML")
-
-                        # # Extracting just the opening tag
-                        opening_tag = outer_html.split('>', 1)[0] + '>'
-                        # areEqual = outer_html == outer_html2
-                        # print("ARE EQUAL: " + str(areEqual))
-                        # print("OPENING match:\n" + opening_tag[:1000])
                         status = Scraping_utilities._Scraping_utilities__extract_id_from_link(post_url)
                         # Now you have the URL, the status, and the matching link element itself
-                        # print("\nURL:", post_url)
                         return (status, post_url, matching_link_element)
-
-                #     else:
-                #         print("no post url or link element")
-                # else:
-                #     print("no links")
 
         except NoSuchElementException:
             # if element is not found
@@ -325,7 +290,6 @@ class Finder:
     @staticmethod
     def __find_posted_time(post, layout, link_element, driver):
         """finds posted time of the facebook post using selenium's webdriver's method"""
-        # print("POST ELEMENT:\n " + post.get_attribute("outerHTML"))
         try:
             # extract element that looks like <abbr class='_5ptz' data-utime="some unix timestamp"> </abbr>
             # posted_time = post.find_element_by_css_selector("abbr._5ptz").get_attribute("data-utime")
@@ -335,16 +299,9 @@ class Finder:
                 )
                 return datetime.datetime.fromtimestamp(float(posted_time)).isoformat()
             elif layout == "new":
-                # There is no aria_label on these link elements anymore
-                # aria_label_value = link_element.get_attribute("aria-label")
-                # timestamp = (
-                #     parse(aria_label_value).isoformat()
-                #     if len(aria_label_value) > 5
-                #     else Scraping_utilities._Scraping_utilities__convert_to_iso(
-                #         aria_label_value
-                #     )
-                # )
-
+                # NOTE There is no aria_label on these link elements anymore
+                # Facebook uses a shadowDOM element to hide timestamp, which is tricky to extract
+                # An unsuccesful attempt to extract time from nested shadowDOMs is below
 
                 js_script = """
                     // Starting from the provided element, find the SVG using querySelector
@@ -374,12 +331,6 @@ class Finder:
 
                 return timestamp
 
-
-        # except dateutil.parser._parser.ParserError:
-        #     timestamp = Scraping_utilities._Scraping_utilities__convert_to_iso(
-        #         aria_label_value
-        #     )
-        #     return timestamp
         except TypeError:
             timestamp = ""
         except Exception as ex:
@@ -461,7 +412,6 @@ class Finder:
     def __find_name(driverOrPost, layout):
         """finds name of the facebook page or post using selenium's webdriver's method"""
         # Attempt to print the outer HTML of the driverOrPost for debugging
-        # print("NAME ELEMENT: " + driverOrPost.get_attribute("outerHTML"))
         
         try:
             if layout == "old":

--- a/facebook_page_scraper/element_finder.py
+++ b/facebook_page_scraper/element_finder.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
-from selenium.common.exceptions import NoSuchElementException
-from .scraping_utilities import Scraping_utilities
-from .driver_utilities import Utilities
+import datetime
+import logging
+import re
 import sys
 import urllib.request
-import re
-from dateutil.parser import parse
+
 import dateutil
-import datetime
+from dateutil.parser import parse
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
-import logging
+
+from .driver_utilities import Utilities
+from .scraping_utilities import Scraping_utilities
 
 logger = logging.getLogger(__name__)
 format = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -358,17 +360,18 @@ class Finder:
             sys.exit(1)
 
     @staticmethod
-    def __find_name(driver, layout):
-        """finds name of the facebook page using selenium's webdriver's method"""
+    def __find_name(driverOrPost, layout):
+        """finds name of the facebook page or post using selenium's webdriver's method"""
         try:
             if layout == "old":
-                name = driver.find_element(By.CSS_SELECTOR, "a._64-f").get_attribute(
+                name = driverOrPost.find_element(By.CSS_SELECTOR, "a._64-f").get_attribute(
                     "textContent"
-                )
+            )
             elif layout == "new":
-                name = driver.find_element(By.TAG_NAME, "strong").get_attribute(
+                name = driverOrPost.find_element(By.TAG_NAME, "strong").get_attribute(
                     "textContent"
                 )
+                
             return name
         except Exception as ex:
             logger.exception("Error at __find_name method : {}".format(ex))

--- a/facebook_page_scraper/scraper.py
+++ b/facebook_page_scraper/scraper.py
@@ -29,7 +29,7 @@ class Facebook_scraper:
 
     # condition,
     # 1) if we reach bottom of the page and post is not longer available, and we don't meet the number of posts that we need to find
-    # 2) if we were given wrong page_name, and it does not exists in fb than no post will exist.
+    # 2) if we were given wrong page_or_group_name, and it does not exists in fb than no post will exist.
     # with above condition being true, the crawler will keep on scrolling the page to find posts
     # and it will stuck in infinite loop, which may cause machine to crash
     # to solve the problem, I have declared a class member "retry",assigned it value 10.
@@ -38,12 +38,12 @@ class Facebook_scraper:
     # on each iteration __close_after_retry is called to check if retry have turned to 0
     # if it returns true,it will break the loop. After coming out of loop,driver will be closed and it will return post whatever was found
 
-    def __init__(self, page_name, posts_count=10, browser="chrome", proxy=None, 
+    def __init__(self, page_or_group_name, posts_count=10, browser="chrome", proxy=None, 
                  timeout=600, headless=True, isGroup=False, username=None, password=None):
-        self.page_name = page_name
+        self.page_or_group_name = page_or_group_name
         self.posts_count = int(posts_count)
-        #self.URL = "https://en-gb.facebook.com/pg/{}/posts".format(self.page_name)
-        self.URL = "https://facebook.com/{}".format(self.page_name)
+        #self.URL = "https://en-gb.facebook.com/pg/{}/posts".format(self.page_or_group_name)
+        self.URL = "https://facebook.com/{}".format(self.page_or_group_name)
         self.browser = browser
         self.__driver = ''
         self.proxy = proxy
@@ -101,10 +101,7 @@ class Facebook_scraper:
         Utilities._Utilities__scroll_down(self.__driver, self.__layout)
         self.__handle_popup(self.__layout)
 
-        # while len(self.__data_dict) <= self.posts_count:
         while len(self.__data_dict) < self.posts_count and elements_have_loaded:
-            print("len of dict: " + str(len(self.__data_dict)))
-            # print("len of limit: " + str(self.posts_count))
             self.__handle_popup(self.__layout)
             # self.__find_elements(name)
             self.__find_elements()
@@ -128,7 +125,7 @@ class Facebook_scraper:
         os.chdir(directory)  # change working directory to given directory
         # headers of the CSV file
         fieldnames = ['id', 'name', 'shares', 'likes', 'loves', 'wow', 'cares', 'sad', 'angry', 'haha', 'reactions_count', 'comments',
-                      'content', 'posted_on', 'video', 'image', 'post_url']
+                      'content', 'posted_on', 'video', 'images', 'post_url']
         # open and start writing to CSV files
         mode = 'w'
         if os.path.exists("{}.csv".format(filename)):
@@ -149,7 +146,7 @@ class Facebook_scraper:
                        'sad': json_data[key]['reactions']['sad'], 'angry': json_data[key]['reactions']['angry'],
                        'haha': json_data[key]['reactions']['haha'], 'reactions_count': json_data[key]['reaction_count'],
                        'comments': json_data[key]['comments'], 'content': json_data[key]['content'], 'posted_on': json_data[key]['posted_on'],
-                       'video': json_data[key]['video'], 'image': " ".join(json_data[key]['image']), 'post_url': json_data[key]['post_url']
+                       'video': json_data[key]['video'], 'images': " ".join(json_data[key]['images']), 'post_url': json_data[key]['post_url']
                        }
                 writer.writerow(row)  # write row to CSV file
 
@@ -192,7 +189,7 @@ class Facebook_scraper:
     def __find_elements(self):
         """find elements of posts and add them to data_dict"""
         all_posts = Finder._Finder__find_all_posts(
-            self.__driver, self.__layout)  # find all posts
+            self.__driver, self.__layout, self.isGroup)  # find all posts
         print("all_posts length: " + str(len(all_posts)))
 
          # remove duplicates from the list
@@ -204,10 +201,11 @@ class Facebook_scraper:
             try:
                 # find post ID from post
                 status, post_url, link_element = Finder._Finder__find_status(
-                    post, self.__layout)
+                    post, self.__layout, self.isGroup)
                 if post_url is None:
                     print("no post_url, skipping")
                     continue
+
 
                 # Split the URL on the '?' character, to detach the referer or uneeded query info
                 parts = post_url.split('?')
@@ -218,106 +216,110 @@ class Facebook_scraper:
                 # finds name depending on if this facebook site is a page or group (we pass a post obj or a webDriver)
                 name = Finder._Finder__find_name(
                     post if self.isGroup else self.__driver, self.__layout)  # find name element for page or for each post if this is used for group pages
+                
+                # NOTE below is  additional fields to scrape, all of which have not been thoroughly tested for groups
+                if not self.isGroup:
+                    # find share from the post
+                    shares = Finder._Finder__find_share(post, self.__layout)
+                    # converting shares to number
+                    # e.g if 5k than it should be 5000
+                    shares = int(
+                        Scraping_utilities._Scraping_utilities__value_to_float(shares))
+                    # find all reactions
+                    reactions_all = Finder._Finder__find_reactions(post)
+                    # find all anchor tags in reactions_all list
+                    all_hrefs_in_react = Finder._Finder__find_reaction(self.__layout, reactions_all,) if type(
+                        reactions_all) != str else ""
+                    # if hrefs were found
+                    # all_hrefs contains elements like
+                    # ["5 comments","54 Likes"] and so on
+                    if type(all_hrefs_in_react) == list:
+                        l = [i.get_attribute("aria-label")
+                            for i in all_hrefs_in_react]
+                    else:
+                        l = []
+                    # extract that aria-label from all_hrefs_in_react list and than extract number from them seperately
+                    # if Like aria-label is in the list, than extract it and extract numbers from that text
 
-                # NOTE below is optional additional fields to scrape, all of which should function except timestamp. Comments may act funky too
-                # find share from the post
-                # shares = Finder._Finder__find_share(post, self.__layout)
-                # converting shares to number
-                # e.g if 5k than it should be 5000
-                # shares = int(
-                #     Scraping_utilities._Scraping_utilities__value_to_float(shares))
-                # find all reactions
-                # reactions_all = Finder._Finder__find_reactions(post)
-                # # find all anchor tags in reactions_all list
-                # all_hrefs_in_react = Finder._Finder__find_reaction(self.__layout, reactions_all,) if type(
-                #     reactions_all) != str else ""
-                # if hrefs were found
-                # all_hrefs contains elements like
-                # ["5 comments","54 Likes"] and so on
-                # if type(all_hrefs_in_react) == list:
-                #     l = [i.get_attribute("aria-label")
-                #          for i in all_hrefs_in_react]
-                # else:
-                #     l = []
-                # extract that aria-label from all_hrefs_in_react list and than extract number from them seperately
-                # if Like aria-label is in the list, than extract it and extract numbers from that text
+                    likes = Scraping_utilities._Scraping_utilities__find_reaction_by_text(
+                        l, "Like")
 
-                # likes = Scraping_utilities._Scraping_utilities__find_reaction_by_text(
-                #     l, "Like")
+                    # if Love aria-label is in the list, than extract it and extract numbers from that text
+                    loves = Scraping_utilities._Scraping_utilities__find_reaction_by_text(
+                        l, "Love")
 
-                # # if Love aria-label is in the list, than extract it and extract numbers from that text
-                # loves = Scraping_utilities._Scraping_utilities__find_reaction_by_text(
-                #     l, "Love")
+                    # if Wow aria-label is in the list, than extract it and extract numbers from that text
+                    wow = Scraping_utilities._Scraping_utilities__find_reaction_by_text(
+                        l, "Wow")
 
-                # # if Wow aria-label is in the list, than extract it and extract numbers from that text
-                # wow = Scraping_utilities._Scraping_utilities__find_reaction_by_text(
-                #     l, "Wow")
+                    # if Care aria-label is in the list, than extract it and extract numbers from that text
+                    cares = Scraping_utilities._Scraping_utilities__find_reaction_by_text(
+                        l, "Care")
+                    # if Sad aria-label is in the list, than extract it and extract numbers from that text
+                    sad = Scraping_utilities._Scraping_utilities__find_reaction_by_text(
+                        l, "Sad")
+                    # if Angry aria-label is in the list, than extract it and extract numbers from that text
+                    angry = Scraping_utilities._Scraping_utilities__find_reaction_by_text(
+                        l, "Angry")
+                    # if Haha aria-label is in the list, than extract it and extract numbers from that text
+                    haha = Scraping_utilities._Scraping_utilities__find_reaction_by_text(
+                        l, "Haha")
 
-                # # if Care aria-label is in the list, than extract it and extract numbers from that text
-                # cares = Scraping_utilities._Scraping_utilities__find_reaction_by_text(
-                #     l, "Care")
-                # # if Sad aria-label is in the list, than extract it and extract numbers from that text
-                # sad = Scraping_utilities._Scraping_utilities__find_reaction_by_text(
-                #     l, "Sad")
-                # # if Angry aria-label is in the list, than extract it and extract numbers from that text
-                # angry = Scraping_utilities._Scraping_utilities__find_reaction_by_text(
-                #     l, "Angry")
-                # # if Haha aria-label is in the list, than extract it and extract numbers from that text
-                # haha = Scraping_utilities._Scraping_utilities__find_reaction_by_text(
-                #     l, "Haha")
+                    # converting all reactions to numbers
+                    # e,g reactions may contain counts like "5k","5m", so converting them to actual number
+                    likes = Scraping_utilities._Scraping_utilities__value_to_float(
+                        likes)
+                    loves = Scraping_utilities._Scraping_utilities__value_to_float(
+                        loves)
+                    wow = Scraping_utilities._Scraping_utilities__value_to_float(
+                        wow)
+                    cares = Scraping_utilities._Scraping_utilities__value_to_float(
+                        cares)
+                    sad = Scraping_utilities._Scraping_utilities__value_to_float(
+                        sad)
+                    angry = Scraping_utilities._Scraping_utilities__value_to_float(
+                        angry)
+                    haha = Scraping_utilities._Scraping_utilities__value_to_float(
+                        haha)
 
-                # # converting all reactions to numbers
-                # # e,g reactions may contain counts like "5k","5m", so converting them to actual number
-                # likes = Scraping_utilities._Scraping_utilities__value_to_float(
-                #     likes)
-                # loves = Scraping_utilities._Scraping_utilities__value_to_float(
-                #     loves)
-                # wow = Scraping_utilities._Scraping_utilities__value_to_float(
-                #     wow)
-                # cares = Scraping_utilities._Scraping_utilities__value_to_float(
-                #     cares)
-                # sad = Scraping_utilities._Scraping_utilities__value_to_float(
-                #     sad)
-                # angry = Scraping_utilities._Scraping_utilities__value_to_float(
-                #     angry)
-                # haha = Scraping_utilities._Scraping_utilities__value_to_float(
-                #     haha)
+                    reactions = {"likes": int(likes), "loves": int(loves), "wow": int(wow), "cares": int(cares), "sad": int(sad),
+                                "angry":
+                                int(angry), "haha": int(haha)}
 
-                # reactions = {"likes": int(likes), "loves": int(loves), "wow": int(wow), "cares": int(cares), "sad": int(sad),
-                #              "angry":
-                #              int(angry), "haha": int(haha)}
+                    # count number of total reactions
+                    total_reaction_count = Scraping_utilities._Scraping_utilities__count_reaction(
+                        reactions)
 
-                # # count number of total reactions
-                # total_reaction_count = Scraping_utilities._Scraping_utilities__count_reaction(
-                #     reactions)
+                    comments = Finder._Finder__find_comments(post, self.__layout)
+                    comments = int(
+                        Scraping_utilities._Scraping_utilities__value_to_float(comments))
+                    
+                    post_content = Finder._Finder__find_content(
+                        post, self.__driver, self.__layout)
+                    # print("comments: " + post_content)
+                    # extract time
+                    posted_time = Finder._Finder__find_posted_time(
+                        post, self.__layout, link_element, self.__driver, self.isGroup)
 
-                comments = Finder._Finder__find_comments(post, self.__layout)
-                comments = int(
-                    Scraping_utilities._Scraping_utilities__value_to_float(comments))
-                post_content = Finder._Finder__find_content(
-                    post, self.__driver, self.__layout)
-                # extract time
-                # posted_time = Finder._Finder__find_posted_time(
-                #     post, self.__layout, link_element, self.__driver)
-
-                # video = Finder._Finder__find_video_url(post)
+                    video = Finder._Finder__find_video_url(post)
 
                 image = Finder._Finder__find_image_url(post, self.__layout)
 
-                #post_url = "https://www.facebook.com/{}/posts/{}".format(self.page_name,status)
+                # post_url = "https://www.facebook.com/{}/posts/{}".format(self.page_or_group_name,status)
 
                 self.__data_dict[status] = {
                     "name": name,
-                    # "shares": shares,
-                    # "reactions": reactions,
-                    # "reaction_count": total_reaction_count,
-                    # "comments": comments,
                     "content": post_content,
-                    # "posted_on": posted_time,
-                    # "video": video,
                     "images": image,
-                    "post_url": post_url
-
+                    "post_url": post_url,
+                    # NOTE only include the following fields if scraping a page, not tested for groups yet
+                    **({"shares": shares} if not self.isGroup else {}),
+                    **({"reactions": reactions} if not self.isGroup else {}),
+                    **({"reaction_count": total_reaction_count} if not self.isGroup else {}),
+                    **({"comments": comments} if not self.isGroup else {}),
+                    **({"posted_on": posted_time} if not self.isGroup else {}),
+                    **({"posted_on": posted_time} if not self.isGroup else {}),
+                    **({"video": video} if not self.isGroup else {}),
                 }
             except Exception as ex:
                 logger.exception(

--- a/facebook_page_scraper/scraper.py
+++ b/facebook_page_scraper/scraper.py
@@ -193,11 +193,11 @@ class Facebook_scraper:
         """find elements of posts and add them to data_dict"""
         all_posts = Finder._Finder__find_all_posts(
             self.__driver, self.__layout)  # find all posts
-        print("len1: " + str(len(all_posts)))
-        # logger.info("len: " + str(len(all_posts)))
+        print("all_posts length: " + str(len(all_posts)))
+
+         # remove duplicates from the list
         all_posts = self.__remove_duplicates(
-            all_posts)  # remove duplicates from the list
-        # print("len2: " + str(len(all_posts)))
+            all_posts) 
 
         # iterate over all the posts and find details from the same
         for post in all_posts:
@@ -205,29 +205,23 @@ class Facebook_scraper:
                 # find post ID from post
                 status, post_url, link_element = Finder._Finder__find_status(
                     post, self.__layout)
-                                # Assuming 'link' is your WebElement
-                # outer_html = link_element.get_attribute("outerHTML")
-
-                # Extracting just the opening tag
-                # opening_tag = outer_html.split('>', 1)[0] + '>'
-
-                # print("OPENING LINK+ELEMENT:\n" + opening_tag[:150])
                 if post_url is None:
                     print("no post_url, skipping")
                     continue
 
-                                # Split the URL on the '?' character
+                # Split the URL on the '?' character, to detach the referer or uneeded query info
                 parts = post_url.split('?')
-
                 # The first part of the list is the URL up to the '?'
                 post_url = parts[0]
-                # TODO add a switch to change name grabbing approach depending on if
-                #       this is a group or page
+
+
+                # finds name depending on if this facebook site is a page or group (we pass a post obj or a webDriver)
                 name = Finder._Finder__find_name(
                     post if self.isGroup else self.__driver, self.__layout)  # find name element for page or for each post if this is used for group pages
 
+                # NOTE below is optional additional fields to scrape, all of which should function except timestamp. Comments may act funky too
                 # find share from the post
-                shares = Finder._Finder__find_share(post, self.__layout)
+                # shares = Finder._Finder__find_share(post, self.__layout)
                 # converting shares to number
                 # e.g if 5k than it should be 5000
                 # shares = int(
@@ -325,10 +319,6 @@ class Facebook_scraper:
                     "post_url": post_url
 
                 }
-
-                # json_formatted_str = json.dumps(self.__data_dict[status], indent=2)
-
-                # print("status: " + str(status) + " \ndict: " + json_formatted_str)  
             except Exception as ex:
                 logger.exception(
                     "Error at find_elements method : {}".format(ex))

--- a/facebook_page_scraper/scraper.py
+++ b/facebook_page_scraper/scraper.py
@@ -139,15 +139,27 @@ class Facebook_scraper:
                 writer.writeheader()  # write headers to CSV file
             # iterate over entire dictionary, write each posts as a row to CSV file
             for key in json_data:
-                # parse post in a dictionary and write it as a single row
-                row = {'id': key, 'name': json_data[key]['name'], 'shares': json_data[key]['shares'],
-                       'likes': json_data[key]['reactions']['likes'], 'loves':  json_data[key]['reactions']['loves'],
-                       'wow': json_data[key]['reactions']['wow'], 'cares': json_data[key]['reactions']['cares'],
-                       'sad': json_data[key]['reactions']['sad'], 'angry': json_data[key]['reactions']['angry'],
-                       'haha': json_data[key]['reactions']['haha'], 'reactions_count': json_data[key]['reaction_count'],
-                       'comments': json_data[key]['comments'], 'content': json_data[key]['content'], 'posted_on': json_data[key]['posted_on'],
-                       'video': json_data[key]['video'], 'images': " ".join(json_data[key]['images']), 'post_url': json_data[key]['post_url']
-                       }
+                post = json_data[key]  # For better readability
+                reactions = post.get('reactions', {})  # Default to an empty dict if 'reactions' does not exist
+                row = {
+                    'id': key,
+                    'name': post.get('name', ''),
+                    'shares': post.get('shares', 0),
+                    'likes': reactions.get('likes', 0),
+                    'loves': reactions.get('loves', 0),
+                    'wow': reactions.get('wow', 0),
+                    'cares': reactions.get('cares', 0),
+                    'sad': reactions.get('sad', 0),
+                    'angry': reactions.get('angry', 0),
+                    'haha': reactions.get('haha', 0),
+                    'reactions_count': post.get('reaction_count', 0),
+                    'comments': post.get('comments', ''),
+                    'content': post.get('content', ''),
+                    'posted_on': post.get('posted_on', ''),
+                    'video': post.get('video', ''),
+                    'images': " ".join(post.get('images', [])),  # Join images list into a string, defaulting to an empty list
+                    'post_url': post.get('post_url', '')
+                }
                 writer.writerow(row)  # write row to CSV file
 
             data_file.close()  # after writing close the file
@@ -216,6 +228,11 @@ class Facebook_scraper:
                 # finds name depending on if this facebook site is a page or group (we pass a post obj or a webDriver)
                 name = Finder._Finder__find_name(
                     post if self.isGroup else self.__driver, self.__layout)  # find name element for page or for each post if this is used for group pages
+                
+
+                post_content = Finder._Finder__find_content(
+                    post, self.__driver, self.__layout)
+                # print("comments: " + post_content)
                 
                 # NOTE below is  additional fields to scrape, all of which have not been thoroughly tested for groups
                 if not self.isGroup:
@@ -294,9 +311,7 @@ class Facebook_scraper:
                     comments = int(
                         Scraping_utilities._Scraping_utilities__value_to_float(comments))
                     
-                    post_content = Finder._Finder__find_content(
-                        post, self.__driver, self.__layout)
-                    # print("comments: " + post_content)
+
                     # extract time
                     posted_time = Finder._Finder__find_posted_time(
                         post, self.__layout, link_element, self.__driver, self.isGroup)
@@ -317,7 +332,6 @@ class Facebook_scraper:
                     **({"reactions": reactions} if not self.isGroup else {}),
                     **({"reaction_count": total_reaction_count} if not self.isGroup else {}),
                     **({"comments": comments} if not self.isGroup else {}),
-                    **({"posted_on": posted_time} if not self.isGroup else {}),
                     **({"posted_on": posted_time} if not self.isGroup else {}),
                     **({"video": video} if not self.isGroup else {}),
                 }

--- a/facebook_page_scraper/scraping_utilities.py
+++ b/facebook_page_scraper/scraping_utilities.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-from datetime import datetime as dt
-import re
-from datetime import datetime, timedelta
-from selenium.webdriver.common.by import By
 import logging
+import re
+from datetime import datetime
+from datetime import datetime as dt
+from datetime import timedelta
+
+from selenium.webdriver.common.by import By
 
 logger = logging.getLogger(__name__)
 format = logging.Formatter(

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = ['selenium==4.1.0',
 
 setuptools.setup(
     name="facebook_page_scraper",
-    version="5.0.2",
+    version="5.0.3",
     author="Sajid Shaikh",
     author_email="shaikhsajid3732@gmail.com",
     description="Python package to scrap facebook's pages front end with no limitations",

--- a/test.py
+++ b/test.py
@@ -24,8 +24,8 @@ class Test_json(unittest.TestCase):
 
         
     def test_scraper_for_json(self): 
-        nyc_sublet_group = facebook_page_scraper.Facebook_scraper("1225966920763001",10,"firefox", isGroup=True,  headless=False, username=fb_email, password=fb_password)
-        json_data = nyc_sublet_group.scrap_to_json()
+        anime_group = facebook_page_scraper.Facebook_scraper("170918513059147",10,"firefox", isGroup=True,  headless=False, username=fb_email, password=fb_password)
+        json_data = anime_group.scrap_to_json()
         data_dictionary = json.loads(json_data)
         
         self.assertEqual(len(data_dictionary),10)
@@ -36,18 +36,14 @@ class Test_json(unittest.TestCase):
 class Test_csv_output(unittest.TestCase):
     
     def test_csv_group(self):
-        nyc_sublet_group = facebook_page_scraper.Facebook_scraper("1225966920763001",5,"firefox",isGroup=True,  headless=True, username=fb_email, password=fb_password)
-        json_data = nyc_sublet_group.scrap_to_json()
-        was_saved = nyc_sublet_group.scrap_to_csv("nyc","/Users/godye/github/SubletSage/backend")
+        anime_group = facebook_page_scraper.Facebook_scraper("170918513059147",5,"firefox",isGroup=True,  headless=True, username=fb_email, password=fb_password)
+        json_data = anime_group.scrap_to_json()
+        was_saved = anime_group.scrap_to_csv("group_test","./")
         self.assertEqual(was_saved,True)
-    # def test_csv_group(self):
-    #     nyc_sublet_group = facebook_page_scraper.Facebook_scraper("1225966920763001",10,"firefox", isGroup=True,  username=fb_email, password=fb_password)
-    #     was_saved = nyc_sublet_group.scrap_to_csv("nyc","/Users/godye/github/SubletSage/backend")
-    #     self.assertEqual(was_saved,True)
 
     def test_csv_page(self):
-        meta_page = facebook_page_scraper.Facebook_scraper("Meta",10,"firefox", headless=False, username=fb_email, password=fb_password)
-        was_saved = meta_page.scrap_to_csv("meta_test","/Users/godye/github/SubletSage/backend")
+        meta_page = facebook_page_scraper.Facebook_scraper("Meta",5,"firefox", headless=False, username=fb_email, password=fb_password)
+        was_saved = meta_page.scrap_to_csv("meta_test","./")
         self.assertEqual(was_saved,True)
 
 

--- a/test.py
+++ b/test.py
@@ -24,11 +24,11 @@ class Test_json(unittest.TestCase):
 
         
     def test_scraper_for_json(self): 
-        anime_group = facebook_page_scraper.Facebook_scraper("170918513059147",10,"firefox", isGroup=True,  headless=False, username=fb_email, password=fb_password)
+        anime_group = facebook_page_scraper.Facebook_scraper("170918513059147",5,"firefox", isGroup=True,  headless=False, username=fb_email, password=fb_password)
         json_data = anime_group.scrap_to_json()
         data_dictionary = json.loads(json_data)
         
-        self.assertEqual(len(data_dictionary),10)
+        self.assertEqual(len(data_dictionary),5)
         self.assertFalse(self.is_name_empty(data_dictionary),"Getting empty strings on name attribute")
         
              
@@ -36,8 +36,8 @@ class Test_json(unittest.TestCase):
 class Test_csv_output(unittest.TestCase):
     
     def test_csv_group(self):
-        anime_group = facebook_page_scraper.Facebook_scraper("170918513059147",5,"firefox",isGroup=True,  headless=True, username=fb_email, password=fb_password)
-        json_data = anime_group.scrap_to_json()
+        print(fb_email)
+        anime_group = facebook_page_scraper.Facebook_scraper("170918513059147",5,"firefox",isGroup=True,  headless=False, username=fb_email, password=fb_password)
         was_saved = anime_group.scrap_to_csv("group_test","./")
         self.assertEqual(was_saved,True)
 

--- a/test.py
+++ b/test.py
@@ -1,7 +1,17 @@
 import json
+import os
 import unittest
 
+from dotenv import load_dotenv
+
 import facebook_page_scraper
+
+load_dotenv()  # take environment variables from .env.
+
+
+# get env password
+fb_password = os.getenv('fb_password')
+fb_email = os.getenv('fb_email')
 
 
 class Test_json(unittest.TestCase):
@@ -14,7 +24,7 @@ class Test_json(unittest.TestCase):
 
         
     def test_scraper_for_json(self): 
-        nyc_sublet_group = facebook_page_scraper.Facebook_scraper("1225966920763001",10,"firefox")
+        nyc_sublet_group = facebook_page_scraper.Facebook_scraper("1225966920763001",10,"firefox", isGroup=True,  headless=False, username=fb_email, password=fb_password)
         json_data = nyc_sublet_group.scrap_to_json()
         data_dictionary = json.loads(json_data)
         
@@ -26,12 +36,17 @@ class Test_json(unittest.TestCase):
 class Test_csv_output(unittest.TestCase):
     
     def test_csv_group(self):
-        nyc_sublet_group = facebook_page_scraper.Facebook_scraper("1225966920763001",10,"firefox", isGroup=True)
+        nyc_sublet_group = facebook_page_scraper.Facebook_scraper("1225966920763001",5,"firefox",isGroup=True,  headless=True, username=fb_email, password=fb_password)
+        json_data = nyc_sublet_group.scrap_to_json()
         was_saved = nyc_sublet_group.scrap_to_csv("nyc","/Users/godye/github/SubletSage/backend")
         self.assertEqual(was_saved,True)
+    # def test_csv_group(self):
+    #     nyc_sublet_group = facebook_page_scraper.Facebook_scraper("1225966920763001",10,"firefox", isGroup=True,  username=fb_email, password=fb_password)
+    #     was_saved = nyc_sublet_group.scrap_to_csv("nyc","/Users/godye/github/SubletSage/backend")
+    #     self.assertEqual(was_saved,True)
 
     def test_csv_page(self):
-        meta_page = facebook_page_scraper.Facebook_scraper("Meta",10,"firefox")
+        meta_page = facebook_page_scraper.Facebook_scraper("Meta",10,"firefox", headless=False, username=fb_email, password=fb_password)
         was_saved = meta_page.scrap_to_csv("meta_test","/Users/godye/github/SubletSage/backend")
         self.assertEqual(was_saved,True)
 

--- a/test.py
+++ b/test.py
@@ -1,8 +1,7 @@
-import facebook_page_scraper
 import json
 import unittest
-import json
 
+import facebook_page_scraper
 
 
 class Test_json(unittest.TestCase):
@@ -15,8 +14,8 @@ class Test_json(unittest.TestCase):
 
         
     def test_scraper_for_json(self): 
-        facebook_ai = facebook_page_scraper.Facebook_scraper("facebookai",10,"firefox")
-        json_data = facebook_ai.scrap_to_json()
+        nyc_sublet_group = facebook_page_scraper.Facebook_scraper("1225966920763001",10,"firefox")
+        json_data = nyc_sublet_group.scrap_to_json()
         data_dictionary = json.loads(json_data)
         
         self.assertEqual(len(data_dictionary),10)
@@ -26,9 +25,14 @@ class Test_json(unittest.TestCase):
 
 class Test_csv_output(unittest.TestCase):
     
-    def test_csv(self):
-        facebook_ai = facebook_page_scraper.Facebook_scraper("facebookai",10,"firefox")
-        was_saved = facebook_ai.scrap_to_csv("fbai","E:\Programming")
+    def test_csv_group(self):
+        nyc_sublet_group = facebook_page_scraper.Facebook_scraper("1225966920763001",10,"firefox", isGroup=True)
+        was_saved = nyc_sublet_group.scrap_to_csv("nyc","/Users/godye/github/SubletSage/backend")
+        self.assertEqual(was_saved,True)
+
+    def test_csv_page(self):
+        meta_page = facebook_page_scraper.Facebook_scraper("Meta",10,"firefox")
+        was_saved = meta_page.scrap_to_csv("meta_test","/Users/godye/github/SubletSage/backend")
         self.assertEqual(was_saved,True)
 
 

--- a/test.py
+++ b/test.py
@@ -36,7 +36,6 @@ class Test_json(unittest.TestCase):
 class Test_csv_output(unittest.TestCase):
     
     def test_csv_group(self):
-        print(fb_email)
         anime_group = facebook_page_scraper.Facebook_scraper("170918513059147",5,"firefox",isGroup=True,  headless=False, username=fb_email, password=fb_password)
         was_saved = anime_group.scrap_to_csv("group_test","./")
         self.assertEqual(was_saved,True)


### PR DESCRIPTION
Added additional parameters to scraper.py to allow for effective scraping of groups. 

Pretty much all the functionality for scraping pages stays the same, but some additions or alterations were made for scraping groups, as they behave slightly differently. 

Note that not all fields that are able to be scraped from pages can be scraped from groups. Namely, the 'name', 'post_url', 'content', and 'images' have been tested for functionality with groups, but all others may or may not work. 'posted_on' does not work yet. 